### PR TITLE
Correction some obvious Typos and LusTRE inconsistent acronyms

### DIFF
--- a/usecasesv1.html
+++ b/usecasesv1.html
@@ -192,7 +192,7 @@
         <p><strong>Elements:</strong></p>
         <ul>
           <li><strong>Domains:</strong> Digital Earth Modeling, Digital Surface
-            Modeling, Spatial Distribution Meausrement, Snow Depth, Snow Water
+            Modeling, Spatial Distribution Measurement, Snow Depth, Snow Water
             Equivalent, Snow Albedo.</li>
           <li><strong>Obligation/motivation:</strong> Funding provided by NASA
             Terrestrial Hydrology, NASA Applied Sciences, and California
@@ -334,7 +334,7 @@
           the same and is of the form : {BASE-URI}/{ONTO-PREFIX}/.</p>
         <p><strong>Elements:</strong></p>
         <ul>
-          <li><strong>Domains:</strong>vocabulary catalog, versioning, metadata
+          <li><strong>Domains:</strong> vocabulary catalog, versioning, metadata
           </li>
           <li><strong>Obligation/motivation:</strong> Provide a unique point of
             vocabularies built within BBC </li>
@@ -388,7 +388,7 @@
           federate queries across multiple SPARQL endpoints. </p>
         <p> <strong>Elements:</strong> </p>
         <ul>
-          <li><b><i>Domains:</i></b>Biological data </li>
+          <li><b><i>Domains:</i></b> Biological data </li>
           <li><b><i>Obligation/motivation:</i></b> Biological researchers are
             often confronted with the inevitable and unenviable task of having
             to integrate their experimental results with those of others. This
@@ -596,7 +596,7 @@
             political information, Transport information.</li>
           <li><b><i>Obligation/motivation:</i></b> Data that must be provided to
             the public under a legal obligation, the called LAI or Brazilian
-            Information Acess Act, edited in 2012.</li>
+            Information Access Act, edited in 2012.</li>
           <li><b><i>Usage: </i></b>Data that is the basis for services to the
             public; Data that has commercial reuse potential.</li>
           <li><b><i>Quality:</i></b> Authoritative, clean data, vetted and
@@ -717,7 +717,7 @@
             they have on the national open data portal. This data has been used
             to do some testing with third-party publications from PiLOD project
             members but this is rather sensitive as a long term strategy
-            (governmental data has to be tracable/trustable as such). The middle
+            (governmental data has to be traceable/trustable as such). The middle
             ground solution currently deployed is the PiLOD platform, a
             (semi)-official platform for publishing register data.</li>
           <li>Privacy: some of the register data is personal or may become so
@@ -1098,8 +1098,8 @@
           and <a href="#R-TrackDataUsage">R-TrackDataUsage</a>. </p>
       </section>
       <!-- LusTRE: Linked Thesaurus fRamework for Environment -->
-      <section rel="bibo:Chapter" resource="#UC-LuSTRE" typeof="bibo:Chapter" id="UC-LuSTRE">
-        <h3 id="h3_UC-LuSTRE" role="heading" aria-level="2">LusTRE: Linked
+      <section rel="bibo:Chapter" resource="#UC-LusTRE" typeof="bibo:Chapter" id="UC-LusTRE">
+        <h3 id="h3_UC-LusTRE" role="heading" aria-level="2">LusTRE: Linked
           Thesaurus fRamework for Environment</h3>
         <p class="contributor">(Contributed by Riccardo Albertoni, CNR-IMATI,
           Genoa, Italy)<br />
@@ -1157,8 +1157,8 @@
             public.</li>
           <li><strong>Quality:</strong> Largely variable.</li>
           <li><strong>Lineage:</strong> Thesauri and controlled vocabulary
-            provided come from Third Parties.</li>
-          <li><strong>Size:</strong> small most of the thesauri size is less
+            provided come from third parties.</li>
+          <li><strong>Size:</strong> Small,  most of the thesauri size is less
             than 100MB.</li>
           <li><strong>Type/format:</strong> LusTRE publishes SKOS/RDF, but the
             thesauri considered for inclusion in LusTRE are not necessarily in
@@ -1311,7 +1311,7 @@
         <p>The Context: Transportation is an important contemporary issue that
           has a direct impact on economic strength, environmental sustainability
           and social equity. Accordingly, transport data — largely produced or
-          gathered by public sector organisations or semi-private entites, quite
+          gathered by public sector organisations or semi-private entities, quite
           often locally — represents one of the most valuable sources of public
           sector information (PSI, also called ‘open data’), a key policy area
           for many, including the European Commission.</p>
@@ -1330,7 +1330,7 @@
           <li>An inclusive infrastructure, based on common open,
             non-discriminatory and interoperable standards and APIs, to which
             operators, service providers, developers and users can connect.</li>
-          <li>An ecosystem wherein universal access and re-usabiliy of transport
+          <li>An ecosystem wherein universal access and re-usability of transport
             data is the rule, not the exception.</li>
         </ul>
         <p>Why is this not happening?</p>
@@ -1389,7 +1389,7 @@
             by Axel Polleres</a> at <a href="http://2014.data-forum.eu/"><abbr
 
               title="European Data Forum">EDF</abbr> 2014</a>).</p>
-        <p>The Open City Data Pipeline aims to to provide an extensible platform
+        <p>The Open City Data Pipeline aims to provide an extensible platform
           to support citizens and city administrators by providing city key
           performance indicators (KPIs), leveraging open data sources. An
           assumption of open data is that “Added value comes from comparable
@@ -1706,7 +1706,7 @@
             information, geographic information, infrastructure information,
             social data and tourism information</li>
           <li><b><i>Obligation/motivation:</i></b> Data that must be provided to
-            the public under a legal obligation (Brazilian Information Acess
+            the public under a legal obligation (Brazilian Information Access
             Act, edited in 2012); Provide public data to citizens.</li>
           <li><b><i>Usage:</i></b> Data that supports democracy and
             transparency; data used by application developers.</li>
@@ -1753,7 +1753,7 @@
             information.</li>
           <li><b><i>Obligation/motivation:</i></b> Data that must be provided to
             the public under a legal obligation, the LAI or Brazilian
-            Information Acess Act, edited in 2012.</li>
+            Information Access Act, edited in 2012.</li>
           <li><b><i>Quality:</i></b> not guaranteed.</li>
           <li><b><i>Type/format:</i></b> Tabular data.</li>
           <li><b><i>Rate of change:</i></b> There is no new releases of the
@@ -2156,11 +2156,11 @@
       <h2 id="challenges" aria-level="1" role="heading">General Challenges</h2>
       <p>The use cases presented in the previous section illustrate a number of
         challenges faced by data publishers and data consumers. These challenges
-        show that some guidance is required on specifc areas and therefore best
+        show that some guidance is required on specific areas and therefore best
         practices should be provided. According to the challenges, a set of
         requirements were defined in such a way that a requirement motivates the
         creation of one or more best practices. Challenges related to Data
-        Qaulity and Data Usage motivated the definition of specifc requirements
+        Quality and Data Usage motivated the definition of specific requirements
         for the Quality and Granularity Description Vocabulary and the Data
         Usage Vocabulary. </p>
       <section rel="bibo:Chapter" resource="#openclosed" typeof="bibo:Chapter">
@@ -2205,7 +2205,7 @@
               limiting factor. From an open data perspective, data only
               available using these these non-HTTP protocols should be
               considered as closed data and, by definition, is not on the Web.
-              It follows that data accessibile by private or
+              It follows that data accessible by private or
               application-specific proprietary access protocol end points are
               also deemed as both closed data and out of scope for data on the
               Web.</p>
@@ -2222,7 +2222,7 @@
       <section rel="bibo:Chapter" resource="#reqsByTheme" typeof="bibo:Chapter">
         <h3 role="heading" aria-level="2" id="reqsByTheme">Requirements by
           Challenge</h3>
-        <p>The table below groups the reqirements derived from the use cases
+        <p>The table below groups the requirements derived from the use cases
           according to the challenges faced by producers and users of data on
           the Web.</p>
         <table>
@@ -2375,7 +2375,7 @@
               <p id="_R-AccessBulk"><em>Data should be available for bulk
                   download</em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-BuildingEye">BuildingEye</a>,
-                <a href="#UC-TheLandPortal">TheLandPortal</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-TheLandPortal">TheLandPortal</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-OKFNTransport">OKFNTransport</a> and <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>.
               </p>
             </dd>
@@ -2433,7 +2433,7 @@
             <dd>
               <p id="_R-DataEnrichment"><em>It should be possible to perform some data enrichment tasks in order to aggregate value to data, therefore providing more value for user applications and services.</em></p>
               <p> <strong>Motivation:</strong><a href="#UC-ISOGeo">ISOGeo</a>, 
-                <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LuSTRE">LuSTRE</a>, 
+                <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LusTRE">LusTRE</a>, 
                 <a href="#UC-MSI">MSI</a>, <a href="#UC-WebObservatory">WebObservatory</a>
               </p>
             </dd>
@@ -2461,7 +2461,7 @@
               <p> <strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a
 
                   href="#UC-BuildingEye">BuildingEye</a>, <a href="#UC-ISOGeo">ISOGeo</a>,
-                <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-MSI">MSI</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
@@ -2471,20 +2471,20 @@
             </dd>
             <dt id="R-FormatMultiple">R-FormatMultiple</dt>
             <dd>
-              <p id="_R-FormatMultiple"><em>Data should be availabe in multiple
+              <p id="_R-FormatMultiple"><em>Data should be available in multiple
                   formats</em></p>
               <p> <strong>Motivation:</strong><a href="#UC-BBC">BBC</a>, <a href="#UC-Bio2RDF">Bio2RDF</a>,
                 <a href="#UC-DutchBaseReg">DutchBaseReg</a>, <a href="#UC-GS1Digital">GS1Digital</a>,
                 <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LATimes">LATimes</a>,
-                <a href="#UC-LuStre">LuStre</a>, <a href="#UC-OpenExperimentalFieldStudies">OpenExperimentalFieldStudies</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OpenExperimentalFieldStudies">OpenExperimentalFieldStudies</a>,
                 <a href="#UC-Tabulae">Tabulae</a> </p>
             </dd>
             <dt id="R-FormatOpen">R-FormatOpen</dt>
             <dd>
-              <p id="_R-FormatOpen"><em>Data should be availabe in an open
+              <p id="_R-FormatOpen"><em>Data should be available in an open
                   format</em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-BuildingEye">BuildingEye</a>,
-                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-MSI">MSI</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
@@ -2492,13 +2492,13 @@
             </dd>
             <dt id="R-FormatStandardized">R-FormatStandardized</dt>
             <dd>
-              <p id="_R-FormatStandardized"><em>Data should be availabe in a
+              <p id="_R-FormatStandardized"><em>Data should be available in a
                   standardized format. Through standardization, interoperability
                   is also expected.</em></p>
               <p> <strong>Motivation:</strong><a href="#UC-Bio2RDF">Bio2RDF</a>,
                 <a href="#UC-BuildingEye">BuildingEye</a>, <a href="#UC-DadosGovBr">DadosGovBr</a>,
                 <a href="#UC-GS1Digital">GS1Digital</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LuStre">LuStre</a>, <a href="#UC-MSI">MSI</a>, <a
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-MSI">MSI</a>, <a
 
                   href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
@@ -2520,7 +2520,7 @@
                   associated with a unique identifier</em></p>
               <p><strong>Motivation:</strong> <a href="#UC-DigitalArchiving">DigitalArchiving</a>,
                 <a href="#UC-DutchBaseReg">DutchBaseReg</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-RDESC">RDESC</a>, <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>
               </p>
             </dd>
@@ -2567,7 +2567,7 @@
               <p id="_R-VocabDocum"><em>Vocabularies should be clearly
                   documented</em></p>
               <p> <strong>Motivation:</strong><a href="#UC-ASO">ASO</a>, <a href="#UC-BuildingEye">BuildingEye</a>,
-                <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
                   href="#UC-RecifeOpenData">RecifeOpenData</a>, <a href="#UC-WebObservatory">WebObservatory</a>,
@@ -2578,7 +2578,7 @@
               <p id="_R-VocabOpen"><em>Vocabularies should be shared in an open
                   way</em></p>
               <p> <strong>Motivation:</strong><a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
                   href="#UC-OpenExperimenatlFieldStudies">OpenExperimenatlFieldStudies</a>,
@@ -2594,7 +2594,7 @@
                 <a href="#UC-BuildingEye">BuildingEye</a>, <a href="#UC-DadosGovBr">DadosGovBr</a>,
                 <a href="#UC-DigitalArchiving">DigitalArchiving</a>, <a href="#UC-DutchBaseReg">DutchBaseReg</a>,
                 <a href="#UC-ISOGeo">ISOGeo</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>,
                 <a href="#UC-OpenExperimenatlFieldStudies">OpenExperimenatlFieldStudies</a>,
                 <a href="#UC-RDESC">RDESC</a>, <a href="#UC-RecifeOpenData">RecifeOpenData</a>,<a
 
@@ -2614,7 +2614,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p> <strong>Motivation:</strong> <a href="#UC-BBC">BBC</a>, <a
 
                   href="#UC-DadosGovBr">DadosGovBr</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-Tabulae">Tabulae</a></p>
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-Tabulae">Tabulae</a></p>
             </dd>
           </dl>
         </section>
@@ -2650,7 +2650,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p id="LicenseAvailable">Data should be associated with a license.</p>
               <p> <strong>Motivation:</strong> <a href="#UC-BuildingEye">BuildingEye</a>,
                 <a href="#UC-DadosGovBr">DadosGovBr</a>, <a href="#UC-ISOGeo">ISOGeo</a>,
-                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-OKFNTransport">OKFNTransport</a>, <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>,
                 <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a></p>
             </dd>
@@ -2675,7 +2675,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
             <dd>
               <p id="_R-DataProductionContext"><em>Production context
                   information should be associated with data if relevant, e.g.
-                  service/proces descriptions. DataProductijonContext is a type
+                  service/process descriptions. DataProductijonContext is a type
                   of metadata, so all metadata requirements also apply here.</em></p>
               <p><strong>Motivation:</strong> <a href="#UC-BuildingEye">BuildingEye</a>,<a
 
@@ -2702,7 +2702,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p id="_R-MetadataAvailable"><em>Metadata should be available</em></p>
               <p><strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a href="#UC-BuildingEye">BuildingEye</a>,
                 <a href="#UC-DadosGovBr">DadosGovBr</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LATimes">LATimes</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-MSI">MSI</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
@@ -2715,7 +2715,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p> <strong>Motivation:</strong> <a href="#UC-BBC">BBC</a>, <a
 
                   href="#UC-BuildingEye">BuildingEye</a>, <a href="#UC-DadosGovBr">DadosGovBr</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-MSI">MSI</a>, <a
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-MSI">MSI</a>, <a
 
                   href="#UC-RecifeOpenData">RecifeOpenData</a>, <a href="#UC-SharePSI">SharePSI
                   ( </a> <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#at">Share-PSI
@@ -2728,7 +2728,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
                   machine-readable</em></p>
               <p><strong>Motivation:</strong> <a href="#UC-BBC">BBC</a>, <a href="#UC-ISOGeo">ISOGeo</a>,
                 <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LATimes">LATimes</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-MSI">MSI</a>, <a
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-MSI">MSI</a>, <a
 
                   href="#UC-RecifeOpenData">RecifeOpenData</a>, <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>,
                 <a href="#UC-WebObservatory">WebObservatory</a></p>
@@ -2740,7 +2740,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
                   also expected.</em></p>
               <p><strong>Motivation:</strong> <a href="#UC-BBC">BBC</a>, <a href="#UC-ISOGeo">ISOGeo</a>,
                 <a href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LATimes">LATimes</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>,
                 <a href="#UC-RecifeOpenData">RecifeOpenData</a>, <a href="#UC-RetratoDaViolencia">RetratoDaViolencia</a>,
                 <a href="#UC-SharePSI">SharePSI ( </a> <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#minhap">Share-PSI
                   Federation ) </a>, <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>,
@@ -2763,7 +2763,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p> <strong>Motivation:</strong> <a href="#UC-Bio2RDF">Bio2RDF</a>,
                 <a href="#UC-DigitalArchiving">DigitalArchiving</a>, <a href="#UC-DutchBaseReg">DutchBaseReg</a>,
                 <a href="#UC-GS1Digital">GS1Digital</a>, <a href="#UC-ISOGeo">ISOGeo</a>,
-                <a href="#UC-LandPortal">LandPortal</a>,<a href="#UC-LuSTRE">LuSTRE</a>,
+                <a href="#UC-LandPortal">LandPortal</a>,<a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-RDESC">RDESC</a>, <a href="#UC-RetratoDaViolencia">RetratoDaViolencia</a>,
                 <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a></p>
             </dd>
@@ -2783,7 +2783,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
                   versioning should be provided. </em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-BBC">BBC</a>, <a
 
-                  href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LuSTRE">LuSTRE</a></p>
+                  href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LusTRE">LusTRE</a></p>
             </dd>
             <dt id="R-ProvAvailable">R-ProvAvailable</dt>
             <dd>
@@ -2794,7 +2794,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
 
                   href="#UC-DadosGovBr">DadosGovBr</a>, <a href="#UC-GS1Digital">GS1Digital</a>,
                 <a href="#UC-ISOGeo">ISOGeo</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-RDESC">RDESC</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-RDESC">RDESC</a>,
                 <a href="#UC-SharePSI">SharePSI ( </a> <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#sarven">Share-PSI
                   270a ) </a>, <a href="#UC-Tabulae">Tabulae</a>, <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>,
                 <a href="#UC-WebObservatory">WebObservatory</a>, </p>
@@ -2857,7 +2857,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p id="_R-QualityComparable"><em>Data should be comparable with
                   other datasets</em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-BuildingEye">BuildingEye</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
                   href="#UC-RecifeOpenData">RecifeOpenData</a>, <a href="#UC-SharePSI">SharePSI
@@ -2870,7 +2870,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p> <strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a
 
                   href="#UC-BuildingEye">BuildingEye</a>, <a href="#UC-LandPortal">LandPortal</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
                 <a href="#UC-OpenCityDataPipeline">OpenCityDataPipeline</a>, <a
 
                   href="#UC-RecifeOpenData">RecifeOpenData</a>, <a href="#UC-RetratoDaViolencia">RetratoDaViolencia</a>,
@@ -2879,13 +2879,13 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
             <dt id="R-QualityMetrics">R-QualityMetrics</dt>
             <dd>
               <p id="_R-QualityMetrics"><em>Data should be associated with a set
-                  of documented, objective and, if available, standarized
+                  of documented, objective and, if available, standardized
                   quality metrics. This set of quality metrics may include
                   user-defined or domain-specific metrics.</em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a
 
                   href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LATimes">LATimes</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-OKFNTransport">OKFNTransport</a>,
               </p>
             </dd>
             <dt id="R-QualityOpinions">R-QualityOpinions</dt>
@@ -2893,7 +2893,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p id="_R-QualityOpinions"><em>Subjective quality opinions on the
                   data should be supported</em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-DadosGovBr">DadosGovBr</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-SharePSI">SharePSI
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-SharePSI">SharePSI
                   ( </a>, <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#feedback">Share-PSI
                   Feedback</a>, <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#feedback2">Share-PSI
                   Feedback 2</a>, <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#france">Share-PSI
@@ -2936,7 +2936,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p> <strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a
 
                   href="#UC-GS1Digital">GS1Digital</a>, <a href="#UC-LATimes">LATimes</a>,
-                <a href="#UC-LuSTRE">LuSTRE</a>, <a href="#UC-RDESC">RDESC</a>,
+                <a href="#UC-LusTRE">LusTRE</a>, <a href="#UC-RDESC">RDESC</a>,
                 <a href="#UC-SharePSI">SharePSI ( </a>, <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#albania">Share-PSI
                   Emergency Albania ) </a>, <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>
               </p>
@@ -2947,7 +2947,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
                   usage of data</em></p>
               <p> <strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a
 
-                  href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LuSTRE">LuSTRE</a>,
+                  href="#UC-LandPortal">LandPortal</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-OpenExperimentalFieldStudies">OpenExperimentalFieldStudies</a>,
                 <a href="#UC-RDESC">RDESC</a>, <a href="#UC-UKOpenResearchForum">UKOpenResearchForum</a>
               </p>
@@ -2957,7 +2957,7 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
               <p id="_R-UsageFeedback"><em>Data consumers should have a way of
                   sharing feedback and rating data.</em></p>
               <p><strong>Motivation:</strong> <a href="#UC-ASO">ASO</a>, <a href="#UC-DadosGovBr">DadosGovBr</a>,
-                <a href="#UC-DataUsage">DataUsage</a>, <a href="#UC-LuStre">LuStre</a>,
+                <a href="#UC-DataUsage">DataUsage</a>, <a href="#UC-LusTRE">LusTRE</a>,
                 <a href="#UC-OKFNTransport">OKFNTransport</a>, <a href="#UC-OpenExperimentalFieldStudies">OpenExperimentalFieldStudies</a>,
                 <a href="#UC-SharePSI">SharePSI ( </a> <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#feedback">Share-PSI
                   Feedback</a>, <a href="http://www.w3.org/2013/share-psi/workshop/samos/report#feedback2">Share-PSI
@@ -3055,14 +3055,14 @@ as this seems to cover code lists/enumerated values but not explicitly.</div>
       <ul>
         <li>Tracking Data Use cases extended to include Ordnance Survey</li>
         <li>RDESC use case added</li>
-        <li>General imrpovements in language style and consistency</li>
+        <li>General improvements in language style and consistency</li>
         <li>Definition of PersistentIdentification modified to emphasize Web
           aspect.</li>
         <li>New requirements added related to closed data.</li>
         <li>R-IndustryReuse, R-PotentialRevenue, R-Archive, R-SynchronizedData
           and R-CoreRegister removed as deemed out of scope for a technical
           requirements document.</li>
-        <li>New use cases added (LuSTRE onwards)</li>
+        <li>New use cases added (LusTRE onwards)</li>
         <li>Removed use-case: Documented Support and Release of Data (too
           generic)</li>
         <li>Removed use-case: Feedback Loop for Corrections (too generic)</li>


### PR DESCRIPTION
Correcting some obvious typos in use cases document
LusTRE inconsistent acronyms (e.g., LuSTRE, Lustre etc)
