### PR TITLE
html RDFa page with data quality examples

### DIFF
--- a/bp.html
+++ b/bp.html
@@ -1470,7 +1470,8 @@ table.bptable caption {
               <p> The example below shows the metadata for the CSV distribution
                 of the Bus Timetable dataset with the inclusion of the data
                 quality metadata. The metadata was defined according to the Data
-                Quality Vocabulary [[DQV]].</p>
+                Quality Vocabulary. Further  examples can be found in the Data
+                Quality Vocabulary document [[DQV]]. </p>
               <pre class="highlight">:timetable-001-csv
    a dcat:Distribution ;
    dcat:downloadURL &lt;http://example.org/bus_timetables_mycity.csv&gt;
@@ -1520,7 +1521,6 @@ table.bptable caption {
               <h5>Human-readable</h5>
                <p><a href="dwbp-example.html">Example page</a> with
                 human-readable data quality information.</p>
-               <p> to be done.</p>
               <div class="note"> This example is not definitive. It will change
                 according to the updates on the Data Quality Vocabulary [[DQV]].
               </div>

--- a/bp.html
+++ b/bp.html
@@ -1498,7 +1498,7 @@ table.bptable caption {
 	a dqv:Dimension ;
 	skos:prefLabel "Availability"@en ;
 	skos:definition "Availability of a dataset is the extent to which data (or some portion of it) is present, obtainable and ready for use."@en ;
-	dqv:hasCategory :assessibility 
+	dqv:hasCategory :accessibility 
 	.
 :completeness
 	a dqv:Dimension ;
@@ -1518,8 +1518,8 @@ table.bptable caption {
 	.
 </pre>
               <h5>Human-readable</h5>
-              <!-- <p><a href="dwbp-example.html">Example page</a> with
-                human-readable data quality information.</p> -->
+               <p><a href="dwbp-example.html">Example page</a> with
+                human-readable data quality information.</p>
                <p> to be done.</p>
               <div class="note"> This example is not definitive. It will change
                 according to the updates on the Data Quality Vocabulary [[DQV]].

--- a/dwbp-example.html
+++ b/dwbp-example.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html prefix="dcat: http://www.w3.org/ns/dcat#
-	dct: http://purl.org/dc/terms/" lang="en">
+	dqv: http://www.w3.org/ns/dqv# 
+	dct: http://purl.org/dc/terms/" lang="en" >
   <head>
     <meta content="text/html; charset=utf-8" http-equiv="content-type">
     <title>DWBP - Examples</title>
@@ -58,7 +59,7 @@
         <p>This is the human-readable version of examples used in the <a href="http://w3.org/TR/dwbp/"><abbr title="Data on the Web Best Practices">DWBP</abbr> document</a>.</p>
       </section>
 
-      <section typeof="dcat:Dataset">
+      <section  resource=":timetable-001"  typeof="dcat:Dataset">
         <p>The dataset description is based on following example:</p>
         <div class="example">
           <p>John works for the Transport Agency of MyCity and he is in charge
@@ -129,8 +130,10 @@
           </tbody>
         </table>
 
-        <h2 id="dataset-distributions">Dataset distributions</h2>
-        <table class="human-readable-example">
+        <h2  id="dataset-distributions">Dataset distributions</h2>
+
+<h3 property="dcat:distribution" resource=":timetable-001-RDF" > RDF Distribution </h3>
+        <table resource=":timetable-001-RDF" typeof="dcat:Distribution" class="human-readable-example">
           <tbody>
             <tr>
               <td>Title</td>
@@ -159,7 +162,43 @@
             </tr>
              <tr>
               <td>Download URL</td>
-              <td property="dcat:downloadURL"> <a href="http://data.mycity.gov/public-transport/road/bus/dataset/timetable.ttl"> http://data.mycity.gov/public-transport/road/bus/dataset/timetable.ttl </a>  </td>
+              <td> <a property="dcat:downloadURL" href="http://data.mycity.gov/public-transport/road/bus/dataset/timetable.ttl">http://data.mycity.gov/public-transport/road/bus/dataset/timetable.ttl</a>  </td>
+            </tr>
+               </tbody>
+        </table>
+<h3 id="timetable-001-CSV" property="dcat:distribution" resource=":timetable-001-CSV"> CSV Distribution </h3>
+ <table  about=":timetable-001-CSV" typeof="dcat:Distribution" class="human-readable-example">
+<span about=":timetable-001-CSV" property="dqv:hasQualityMeasure" resource=":measure1" />
+<span about=":timetable-001-CSV" property="dqv:hasQualityMeasure" resource=":measure2" />
+          <tbody>
+            <tr>
+              <td>Title</td>
+              <td property="dct:title">timetable-001-CSV</td>
+            </tr>
+            <tr>
+              <td>Description</td>
+              <td property="dct:description">CSV distribution MyCity_busTimetable dataset.</td>
+            </tr>
+             <tr>
+              <td>Media type</td>
+              <td property="dcat:mediaType">text/csv</td>
+            </tr>
+            <tr>
+              <td>License</td>
+              <td> <a href="http://creativecommons.org/licenses/by-sa/3.0/"> CC
+                  BY-SA 3.0 </a></td>
+            </tr>
+             <tr>
+              <td>Publication date</td>
+              <td><span property="dct:issued" content="2015-05-05" datatype="xsd:date">2015-05-05</span></td>
+            </tr>
+            <tr>
+              <td>Last modification</td>
+              <td><span property="dct:modified" content="2015-05-05" datatype="xsd:date">2015-05-05</span></td>
+            </tr>
+             <tr>
+              <td>Download URL</td>
+              <td> <a property="dcat:downloadURL" href="http://data.mycity.gov/public-transport/road/bus/dataset/timetable.csv">http://data.mycity.gov/public-transport/road/bus/dataset/timetable.csv</a>  </td>
             </tr>
                </tbody>
         </table>
@@ -175,6 +214,73 @@
         </table>
 
       </section>
+
+ <section>
+      <h2> Dataset /Distribution quality </h2>
+<section>
+<h3> Quality measure 1 </h3>
+
+<table class="human-readable-example" resource=":measure1" typeof="dqv:QualityMeasure">
+ <tr>
+	<td property="dqv:metric" resource=":csvCompletenessMetric">Metric</td>
+	<td about=":csvCompletenessMetric" typeof="dqv:Metric"> <span property="skos:definition">Ratio between the number of real-word objects represented in the cvs and the total number of real objects.</span> </td>  
+ </tr>
+ <tr>
+        <td>Value </td>
+        <td> <span property="dqv:value" datatype="xsd:double">0.5</span> (Double)</td>
+</tr>
+ <tr>
+        <td>Computed on</td>
+        <td property="dqv:computedOn" resource=":timetable-001-CSV"><a href="#timetable-001-CSV">timetable-001-CSV </a></td>
+ </tr>
+<tr>
+     <td  about=":csvCompletenessMetric" property="dqv:hasDimension" resource=":completeness"> Dimension </td>
+     <td>
+     	<table  class="human-readable-example" about=":completeness"  typeof="dqv:Dimension" property="dqv:hasCategory" resource=":intrinsicDimensions">
+		<tr>
+			<td><span property="skos:prefLabel">Completeness</span></td>
+		</tr>
+		<tr>
+			<td><span property="skos:definition">Completeness refers to the degree to which all required information is present in a particular dataset.</span></td>
+		</tr>
+	</table>
+     </td>
+</tr>
+
+</table>
+
+<h3> Quality measure 2 </h3>
+<table class="human-readable-example" resource=":measure2" typeof="dqv:QualityMeasure">
+ <tr>
+	<td property="dqv:metric" resource=":availabilityMetric">Metric</td>
+	<td about=":availabilityMetric" typeof="dqv:Metric"> <span property="skos:definition">It checks if dcat:downloadURL  is available and  if its value is dereferenceable.</span> </td>  
+ </tr>
+ <tr>
+        <td>Value </td>
+        <td> <span property="dqv:value" datatype="xsd:boolean">true</span> (Boolean)</td>
+</tr>
+ <tr>
+        <td>Computed on</td>
+        <td property="dqv:computedOn" resource=":timetable-001-CSV"><a href="#timetable-001-CSV">timetable-001-CSV </a></td>
+ </tr>
+<tr>
+     <td  about=":availabilityMetric" property="dqv:hasDimension" resource=":availabity"> Dimension </td>
+     <td>
+     	<table  class="human-readable-example" about=":availabity"  typeof="dqv:Dimension" property="dqv:hasCategory" resource=":accessibility">
+		<tr>
+			<td><span property="skos:prefLabel">Availability</span></td>
+		</tr>
+		<tr>
+			<td><span property="skos:definition">Availability of a dataset is the extent to which data (or some portion of it) is present, obtainable and ready for use.</span></td>
+		</tr>
+	</table>
+     </td>
+</tr>
+
+</table>
+
+
+</section>
     </div>
   </body>
 </html>


### PR DESCRIPTION
I have inserted   in  dwbp-example.html the human readable example  for Quality.

I am not a RDFa expert, I was forced to  modify some of the existing RDFa part in order to produce RDF consistent with the quality example mentioned  in BP document.

@newtoncalegari  please doublecheck if this is  consistent with your expectations.

Best, 
Riccardo
