### PR TITLE
string, not URI for dct:identifier in ex 6

### DIFF
--- a/publishing-snapshots/NOTE-vocab-duv-20161215/index.html
+++ b/publishing-snapshots/NOTE-vocab-duv-20161215/index.html
@@ -2069,7 +2069,7 @@ pre red { color: red;
 :route-calculator a duv:UsageTool ;
       dct:title "Route Calculator"^^xsd:string ;
       dct:created "2016-03-04"^^xsd:date ;
-      dct:identifier &lt;http://dx.doi.org/10.0902/1975.16&gt;^^xsd:anyURI    
+      dct:identifier "http://dx.doi.org/10.0902/1975.16"^^xsd:anyURI
       .
 
 </pre>

--- a/vocab-du.html
+++ b/vocab-du.html
@@ -2080,7 +2080,7 @@ pre red { color: red;
 :route-calculator a duv:UsageTool ;
       dct:title "Route Calculator"^^xsd:string ;
       dct:created "2016-03-04"^^xsd:date ;
-      dct:identifier &lt;http://dx.doi.org/10.0902/1975.16&gt;^^xsd:anyURI    
+      dct:identifier "http://dx.doi.org/10.0902/1975.16"^^xsd:anyURI
       .
 
 </pre>


### PR DESCRIPTION
See https://lists.w3.org/Archives/Public/public-dwbp-wg/2016Dec/0009.html