### PR TITLE
fix dqv:QualityAnnotation definition

### DIFF
--- a/dqv.jsonld
+++ b/dqv.jsonld
@@ -25,7 +25,7 @@
     "@id" : "_:b6",
     "@type" : "owl:Restriction",
     "hasValue" : "dqv:qualityAssessment",
-    "onProperty" : "oa:motivation"
+    "onProperty" : "oa:motivatedBy"
   }, {
     "@id" : "_:b7",
     "foaf:name" : "Christophe Guéret"

--- a/dqv.rdf
+++ b/dqv.rdf
@@ -60,7 +60,7 @@
             <skos:prefLabel xml:lang="en">Quality assessment</skos:prefLabel>
           </oa:Motivation>
         </owl:hasValue>
-        <owl:onProperty rdf:resource="http://www.w3.org/ns/oa#motivation"/>
+        <owl:onProperty rdf:resource="http://www.w3.org/ns/oa#motivatedBy"/>
       </owl:Restriction>
     </owl:equivalentClass>
     <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/oa#Annotation"/>

--- a/dqv.ttl
+++ b/dqv.ttl
@@ -76,7 +76,7 @@ dqv:QualityAnnotation a owl:Class, rdfs:Class ;
   rdfs:subClassOf oa:Annotation ;
   owl:equivalentClass
     [ rdf:type owl:Restriction ; 
-      owl:onProperty oa:motivation ;
+      owl:onProperty oa:motivatedBy ;
       owl:hasValue dqv:qualityAssessment
     ] .
 


### PR DESCRIPTION
This PR fixes a typo in the RDF representations of `dqv:QualityAnnotation`:
`oa:motivation` (which is not defined) was used instead of `oa:motivatedBy`.

In the HTML file the correct IRI has already been used.